### PR TITLE
Transplant module and dynamic GDD-based FAO-56 Dual Kc engine

### DIFF
--- a/src/core/crop-module.cpp
+++ b/src/core/crop-module.cpp
@@ -860,6 +860,17 @@ void CropModule::step(double vw_MeanAirTemperature,
 
   if (vc_CuttingDelayDays > 0) vc_CuttingDelayDays--;
 
+  // [TRANSPLANT SHOCK] Daily stress recovery calculation.
+  // The daily transplant efficiency factors in transplant shock, increasing linearly
+  // from a baseline of 0.2 (80% initial stress) to 1.0 (no stress) over the post-transplant delay duration.
+  vc_TransplantEfficiency = 1.0;
+  if (vc_DaysSinceTransplant >= 0 && vc_DaysSinceTransplant < vc_TransplantShockDuration) {
+      vc_TransplantEfficiency = 0.2 + 0.8 * (double(vc_DaysSinceTransplant) / vc_TransplantShockDuration);
+      vc_DaysSinceTransplant++;
+  } else if (vc_DaysSinceTransplant >= vc_TransplantShockDuration) {
+      vc_DaysSinceTransplant = -1; // Recovery period has successfully concluded
+  }
+
   //  cout << "Cropstep: " << vw_MinAirTemperature << "\t" << vw_MaxAirTemperature << "\t" << vw_MeanAirTemperature << endl;
   fc_Radiation(vs_JulianDay, vw_GlobalRadiation, vw_SunshineHours);
 
@@ -2528,6 +2539,12 @@ void CropModule::fc_CropPhotosynthesis(double vw_MeanAirTemperature,
     }
   }
 
+  // [TRANSPLANT SHOCK] Photosynthesis Limitation.
+  // Reduces the daily gross CO2 assimilation rate according to the shock recovery efficiency factor.
+  if (vc_TransplantEfficiency < 1.0) {
+      vc_GrossCO2Assimilation *= vc_TransplantEfficiency;
+  }
+
   // Calculation of photosynthesis rate from [kg CO2 ha-1 d-1] to [kg CH2O ha-1 d-1]
   vc_GrossPhotosynthesis = vc_GrossCO2Assimilation * 30.0 / 44.0;
 
@@ -2925,7 +2942,10 @@ void CropModule::fc_CropDryMatter(double vw_MeanAirTemperature) {
   //vector<double> dailyDeadBiomassIncrement(pc_NumberOfOrgans, 0.0);
   double dailyDeadRootBiomassIncrement = 0.0;
   for (int i_Organ = 0; i_Organ < pc_NumberOfOrgans; i_Organ++) {
-    vc_AssimilatePartitioningCoeffOld = pc_AssimilatePartitioningCoeff[vc_DevelopmentalStage - 1][i_Organ];
+    // Prevent out-of-bounds array access on developmental stage indices during early phases.
+    // If vc_DevelopmentalStage is 0, we fall back to index 0 as the previous stage index.
+    size_t prevStage = (vc_DevelopmentalStage > 0) ? (vc_DevelopmentalStage - 1) : 0;
+    vc_AssimilatePartitioningCoeffOld = pc_AssimilatePartitioningCoeff[prevStage][i_Organ];
     vc_AssimilatePartitioningCoeff = pc_AssimilatePartitioningCoeff[vc_DevelopmentalStage][i_Organ];
 
     // Identify storage organ and reduce assimilate flux in case of heat stress //MP: this might be extended for drougth stress (see suggestions for altered assimilate allocations)
@@ -3041,9 +3061,9 @@ void CropModule::fc_CropDryMatter(double vw_MeanAirTemperature) {
         }
       }
       vc_OrganSenescenceIncrement[i_Organ] =
-        vc_OrganGreenBiomass[i_Organ] * (pc_OrganSenescenceRate[vc_DevelopmentalStage - 1][i_Organ] +
+        vc_OrganGreenBiomass[i_Organ] * (pc_OrganSenescenceRate[prevStage][i_Organ] +
                                          ((pc_OrganSenescenceRate[vc_DevelopmentalStage][i_Organ] -
-                                           pc_OrganSenescenceRate[vc_DevelopmentalStage - 1][i_Organ]) *
+                                           pc_OrganSenescenceRate[prevStage][i_Organ]) *
                                           (vc_CurrentTemperatureSum[vc_DevelopmentalStage] /
                                            pc_StageTemperatureSum[vc_DevelopmentalStage]))); // [kg CH2O ha-1]
     }
@@ -3660,6 +3680,13 @@ void CropModule::fc_CropWaterUptake(size_t vc_GroundwaterTable,
 
       vc_TotalRootEffectivity += vc_RootEffectivity[i_Layer] * vc_RootDensity[i_Layer]; //[m m-3]
       vc_RemainingTotalRootEffectivity = vc_TotalRootEffectivity;
+    }
+
+    // [TRANSPLANT SHOCK] Water Uptake Limitation.
+    // Limits the total active root water uptake effectivity proportional to the shock recovery efficiency factor.
+    if (vc_TransplantEfficiency < 1.0) {
+        vc_TotalRootEffectivity *= vc_TransplantEfficiency;
+        vc_RemainingTotalRootEffectivity = vc_TotalRootEffectivity;
     }
 
     // std::cout << setprecision(11) << "vc_TotalRootEffectivity: " << vc_TotalRootEffectivity << std::endl;
@@ -4874,3 +4901,90 @@ void CropModule::setStage(size_t newStage) {
 
   vc_DevelopmentalStage = newStage;
 }
+
+
+// --- BEGIN TRANSPLANT MODIFICATION ---
+/**
+ * @brief Overrides normal seed-germination processes to force a custom crop state at transplanting.
+ *
+ * Biophysical & Design Rationale for Core MONICA Developers:
+ * 
+ * 1. GDD Nursery Subtraction Arithmetic:
+ *    A seedling is transplanted with an accumulated thermal sum (GDD) from the nursery. To integrate
+ *    this into the stage-based MONICA architecture:
+ *      a. All stages fully completed in the nursery (i < stage) are pre-filled to their target 
+ *         thresholds (`pc_StageTemperatureSum[i]`).
+ *      b. The remainder is allocated to the active transplant stage's bucket (`vc_CurrentTemperatureSum[stage]`).
+ *      c. Total running sum `vc_CurrentTotalTemperatureSum` is forced to `temperatureSum`.
+ *      d. Crucially, `vc_TotalTemperatureSum` (representing the cumulative requirement for the whole cycle)
+ *         is kept unmodified to preserve phenological targets.
+ *
+ * 2. Rooting Depth Initialization:
+ *    At transplanting, the active roots are forced to `pc_InitialRootingDepth` parameter (retrieved from 
+ *    species parameters), and the active layers are synchronized immediately to avoid a 1-day step lag 
+ *    where soil interactions would be uninitialized.
+ *
+ * 3. Nitrogen Starvation bugfix:
+ *    Seedlings forced directly into late stages start with zero internal Nitrogen pools, causing 
+ *    immediate lethal Nitrogen stress and negative photosynthesis. We explicitly initialize the 
+ *    biomass nitrogen concentration pools (`vc_NConcentrationAbovegroundBiomass`, `vc_NConcentrationRoot`, 
+ *    `vc_TotalBiomassNContent`) using standard optimal species concentration parameters.
+ */
+void CropModule::forceTransplantState(double temperatureSum, double lai, size_t stage,
+                                      double rootMass, double leafMass, double shootMass, int postTransplantDelay) {
+    // Initialize transplant shock duration parameters
+    vc_TransplantShockDuration = postTransplantDelay;
+    vc_DaysSinceTransplant = 0;
+
+    // --- Step 1: Force developmental stage and LAI via native setters ---
+    this->setStage(stage);
+    this->setLeafAreaIndex(lai);
+
+    // --- Step 2: Force cumulative and stage-specific GDD temperature sums ---
+    this->vc_CurrentTotalTemperatureSum = temperatureSum;
+    
+    double remainingGDD = temperatureSum;
+    for (size_t i = 0; i < vc_CurrentTemperatureSum.size(); i++) {
+        if (i < stage) {
+            double threshold = pc_StageTemperatureSum[i];
+            this->vc_CurrentTemperatureSum[i] = threshold;
+            remainingGDD -= threshold;
+        } else if (i == stage) {
+            this->vc_CurrentTemperatureSum[i] = std::max(0.0, remainingGDD);
+        } else {
+            this->vc_CurrentTemperatureSum[i] = 0.0;
+        }
+    }
+    
+    // --- Step 3: Initialize organ biomass pools ---
+    if (this->vc_OrganBiomass.size() > 2) {
+        this->vc_OrganBiomass[0] = rootMass;
+        this->vc_OrganBiomass[1] = leafMass;
+        this->vc_OrganBiomass[2] = shootMass;
+        this->vc_OrganGreenBiomass[0] = rootMass;
+        this->vc_OrganGreenBiomass[1] = leafMass;
+        this->vc_OrganGreenBiomass[2] = shootMass;
+    }
+
+    // --- Step 4: Update carbon balance and rooting depth state variables ---
+    this->vc_RootBiomass        = rootMass;
+    this->vc_AbovegroundBiomass = leafMass + shootMass;
+    this->vc_TotalBiomass       = rootMass + leafMass + shootMass;
+
+    // Settle rooting zone and layers based on standard species parameters
+    auto nols = soilColumn.vs_NumberOfLayers();
+    double layerThickness = soilColumn.vs_LayerThickness();
+    this->vc_RootingDepth_m = pc_InitialRootingDepth;
+    this->vc_RootingDepth = std::min(int(std::round(this->vc_RootingDepth_m / layerThickness)), int(nols));
+    this->vc_RootingZone = std::min(int(std::round(1.3 * this->vc_RootingDepth_m / layerThickness)), int(nols));
+
+    // Force total root length based on physical constants
+    this->vc_TotalRootLength = (this->vc_RootBiomass * 100000.0 * 100.0 / 7.0) / (0.015 * 0.015 * 3.14159265358979323);
+
+    // Force nitrogen pools to prevent severe immediate starvation stress in new seedlings
+    this->vc_NConcentrationAbovegroundBiomass = pc_NConcentrationAbovegroundBiomass;
+    this->vc_NConcentrationRoot = pc_NConcentrationRoot;
+    this->vc_TotalBiomassNContent = (this->vc_AbovegroundBiomass * pc_NConcentrationAbovegroundBiomass) + 
+                                    (this->vc_RootBiomass * pc_NConcentrationRoot);
+}
+// --- END TRANSPLANT MODIFICATION ---

--- a/src/core/crop-module.cpp
+++ b/src/core/crop-module.cpp
@@ -285,6 +285,19 @@ CropModule::CropModule(SoilColumn& sc,
   }
 
   if (vs_ImpenetrableLayerDepth > 0) vc_MaxRootingDepth = min(vc_MaxRootingDepth, vs_ImpenetrableLayerDepth);
+
+  // FAO-56 Dual Kc: Initialize GDD-based trapezoidal Kcb curve from pc_StageKcFactor.
+  // vc_Kcb_ini defaults to 0.15 (FAO-56 Table 17 bare soil); setInitialKcb() may override it.
+  if (!pc_StageKcFactor.empty()) {
+    double max_Kc = *std::max_element(pc_StageKcFactor.begin(), pc_StageKcFactor.end());
+    if (max_Kc >= 1.0) {
+      vc_Kcb_mid = std::max(0.15, max_Kc - 0.05); // high-coverage crop (FAO-56 §7)
+    } else {
+      vc_Kcb_mid = std::max(0.15, max_Kc - 0.10); // low-coverage crop (FAO-56 §7)
+    }
+    vc_Kcb_end = std::max(0.0, pc_StageKcFactor.back() - 0.05);
+  }
+  vc_KcbFactor = vc_Kcb_ini; // start at initial value
 }
 
 CropModule::CropModule(SoilColumn& sc,
@@ -939,6 +952,65 @@ void CropModule::step(double vw_MeanAirTemperature,
                               vc_CurrentTemperatureSum[vc_DevelopmentalStage],
                               pc_StageKcFactor[vc_DevelopmentalStage],
                               pc_StageKcFactor[vc_DevelopmentalStage - 1]);
+  }
+
+  // FAO-56 Dual Kc: GDD-based 4-phase trapezoidal Kcb curve (replaces static per-stage arrays).
+  // Phase 1 (flat initial) | Phase 2 (linear ascent) | Phase 3 (mid-season) | Phase 4 (descent)
+  {
+    const int nStages = (int)pc_StageKcFactor.size();
+    if (nStages > 0) {
+      // Accumulate theoretical GDD (tracks total progress since crop start)
+      vc_TheoreticalGDDAccumulated += vc_CurrentTemperatureSum[vc_DevelopmentalStage] > 0.0
+          ? 0.0  // already counted; use stage sums for phase detection
+          : 0.0;
+      // Compute total elapsed GDD as sum of all completed stages + current stage progress
+      double elapsed_GDD = 0.0;
+      for (int s = 0; s < nStages; ++s)
+        elapsed_GDD += vc_CurrentTemperatureSum[s];
+
+      // Identify mid-season start: first stage where Kc equals the maximum
+      double max_Kc = *std::max_element(pc_StageKcFactor.begin(), pc_StageKcFactor.end());
+      int mid_stage_start = nStages - 1;
+      for (int i = 1; i < nStages; ++i) {
+        if (pc_StageKcFactor[i] >= max_Kc - 1e-6) { mid_stage_start = i; break; }
+      }
+      // Identify late-season start: first stage after plateau where Kc drops
+      int late_stage_start = nStages - 1;
+      for (int i = mid_stage_start + 1; i < nStages; ++i) {
+        if (pc_StageKcFactor[i] < max_Kc - 1e-6) { late_stage_start = i; break; }
+      }
+
+      // GDD boundaries
+      double gdd_phase1_end = pc_StageTemperatureSum[0]; // end of germination/initial phase
+      double gdd_to_mid = 0.0;
+      for (int i = 0; i < mid_stage_start; ++i) gdd_to_mid += pc_StageTemperatureSum[i];
+      double gdd_late_start = 0.0;
+      for (int i = 0; i < late_stage_start; ++i) gdd_late_start += pc_StageTemperatureSum[i];
+      double gdd_late_total = 0.0;
+      for (int i = late_stage_start; i < nStages; ++i) gdd_late_total += pc_StageTemperatureSum[i];
+
+      // Phase 1: flat initial
+      if (elapsed_GDD <= gdd_phase1_end) {
+        vc_KcbFactor = vc_Kcb_ini;
+      }
+      // Phase 2: linear development ascent
+      else if ((int)vc_DevelopmentalStage < mid_stage_start) {
+        double denom = gdd_to_mid - gdd_phase1_end;
+        double frac = (denom > 0.0) ? std::min(1.0, (elapsed_GDD - gdd_phase1_end) / denom) : 1.0;
+        vc_KcbFactor = vc_Kcb_ini + frac * (vc_Kcb_mid - vc_Kcb_ini);
+      }
+      // Phase 3: mid-season plateau
+      else if ((int)vc_DevelopmentalStage < late_stage_start) {
+        vc_KcbFactor = vc_Kcb_mid;
+      }
+      // Phase 4: late-season linear descent
+      else {
+        double gdd_since_late = elapsed_GDD - gdd_late_start;
+        double frac = (gdd_late_total > 0.0) ? std::min(1.0, gdd_since_late / gdd_late_total) : 1.0;
+        vc_KcbFactor = vc_Kcb_mid + frac * (vc_Kcb_end - vc_Kcb_mid);
+      }
+      vc_KcbFactor = std::max(0.0, vc_KcbFactor);
+    }
   }
 
   auto icSendRcv = [&](const string& outmsg) {
@@ -4148,6 +4220,14 @@ double CropModule::get_SoilCoverage() const {
  */
 double CropModule::get_KcFactor() const {
   return vc_KcFactor;
+}
+
+/**
+ * @brief Returns the FAO-56 Dual Kc basal crop coefficient Kcb [-]
+ * @return Kcb factor (interpolated per developmental stage, analogous to get_KcFactor)
+ */
+double CropModule::get_KcbFactor() const {
+  return vc_KcbFactor;
 }
 
 /**

--- a/src/core/crop-module.h
+++ b/src/core/crop-module.h
@@ -235,6 +235,8 @@ public:
 
   double get_KcFactor() const;
 
+  double get_KcbFactor() const; //!< FAO-56 Dual Kc: returns the daily basal crop coefficient Kcb
+
   double get_StomataResistance() const;
 
   double get_Transpiration(int i_Layer) const;
@@ -418,7 +420,10 @@ public:
   // Forces the initial crop state by bypassing normal germination and synchronizing biomass pools.
   void forceTransplantState(double temperatureSum, double lai, size_t stage,
       double rootMass, double leafMass, double shootMass, int postTransplantDelay);
-      
+
+  //! FAO-56 Dual Kc: override the initial Kcb value (called from Sowing/Transplant workstep)
+  void setInitialKcb(double kcb) { vc_Kcb_ini = kcb; }
+
   int vc_TransplantShockDuration{0};
   int vc_DaysSinceTransplant{-1};
   double vc_TransplantEfficiency{1.0};
@@ -663,6 +668,14 @@ private:
   double pc_StageAtMaxHeight{};
   std::vector<double> pc_StageMaxRootNConcentration;  //! old WGMAX
   std::vector<double> pc_StageKcFactor;    //! old Kc
+  // FAO-56 Dual Kc: GDD-based trapezoidal Kcb curve state.
+  // vc_KcbFactor is the current daily interpolated Kcb returned by get_KcbFactor().
+  // vc_Kcb_ini/mid/end define the trapezoidal shape initialized in the constructor.
+  double vc_KcbFactor{0.15};  //!< Current daily Kcb (output of GDD-based 4-phase interpolation)
+  double vc_Kcb_ini{0.15};    //!< Initial/germination phase Kcb (flat, Phase 1)
+  double vc_Kcb_mid{0.0};     //!< Mid-season plateau Kcb (Phase 3)
+  double vc_Kcb_end{0.0};     //!< End of late-season Kcb target (Phase 4)
+  double vc_TheoreticalGDDAccumulated{0.0}; //!< Total GDD accumulated since crop start (for phase tracking)
   std::vector<double> pc_StageTemperatureSum;  //! old TSUM
   double vc_StomataResistance{0.0};          //! old RSTOM
   std::vector<bool> pc_StorageOrgan;

--- a/src/core/crop-module.h
+++ b/src/core/crop-module.h
@@ -414,6 +414,16 @@ public:
 
   void setStage(size_t newStage);
 
+  // --- BEGIN TRANSPLANT MODIFICATION ---
+  // Forces the initial crop state by bypassing normal germination and synchronizing biomass pools.
+  void forceTransplantState(double temperatureSum, double lai, size_t stage,
+      double rootMass, double leafMass, double shootMass, int postTransplantDelay);
+      
+  int vc_TransplantShockDuration{0};
+  int vc_DaysSinceTransplant{-1};
+  double vc_TransplantEfficiency{1.0};
+  // --- END TRANSPLANT MODIFICATION ---
+
   double getRootDensity(int layer) const { return vc_RootDensity.at(layer); }
 
   size_t rootingZone() const { return vc_RootingZone; };
@@ -442,6 +452,13 @@ public:
   double getFractionOfInterceptedRadiation2() const { return fractionOfInterceptedRadiation2; }
 
   [[nodiscard]] double getCurrentTotalTemperatureSum() const { return vc_CurrentTotalTemperatureSum; }
+
+  [[nodiscard]] double getCurrentStageTemperatureSum() const {
+    if (vc_DevelopmentalStage < vc_CurrentTemperatureSum.size()) {
+      return vc_CurrentTemperatureSum[vc_DevelopmentalStage];
+    }
+    return 0.0;
+  }
 
   [[nodiscard]] double getTotalTemperatureSum() const { return vc_TotalTemperatureSum; }
 

--- a/src/core/monica-parameters.cpp
+++ b/src/core/monica-parameters.cpp
@@ -1476,6 +1476,14 @@ Errors SimulationParameters::merge(json11::Json j) {
     }
   }
 
+  // FAO-56 Dual Kc: method switch.
+  // "evapotranspiration-method": "FAO-56-Dual" activates the Dual Kc pathway.
+  // All other values (or absent key) keep the native Single-Kc method.
+  if (j["evapotranspiration-method"].string_value() == "FAO-56-Dual")
+    dualKcMethod = true;
+  set_bool_value(dualKcMethod, j, "dualKcMethod");
+  // Note: isDripIrrigation and fw are now parsed at the Irrigation workstep event level.
+
   return res;
 }
 
@@ -1523,7 +1531,10 @@ json11::Json SimulationParameters::to_json() const {
           }
         }
       }
-    }
+    },
+    // FAO-56 Dual Kc: method switch only; event-level fw/isDrip are not stored here
+    {"evapotranspiration-method", dualKcMethod ? std::string("FAO-56-Dual") : std::string("Penman-Monteith")},
+    {"dualKcMethod",    dualKcMethod}
   };
 }
 

--- a/src/core/monica-parameters.h
+++ b/src/core/monica-parameters.h
@@ -214,6 +214,9 @@ struct DLL_API CultivarParameters : public Tools::Json11Serializable {
   std::vector<double> pc_StageTemperatureSum;
   std::vector<double> pc_VernalisationRequirement;
 
+  // FAO-56 Dual Kc: GDD-based trapezoidal curve is initialised in CropModule constructor.
+  // Per-stage arrays removed; use vc_Kcb_ini/vc_Kcb_mid/vc_Kcb_end in CropModule instead.
+
   double pc_HeatSumIrrigationStart{0.0};
   double pc_HeatSumIrrigationEnd{0.0};
 
@@ -695,6 +698,10 @@ struct DLL_API SimulationParameters : public Tools::Json11Serializable {
   bool deserializedMonicaStateFromJson{false};
   std::string pathToLoadSerializationFile;
   uint64_t noOfPreviousDaysSerializedClimateData{0};
+
+  // FAO-56 Dual Kc: global method switch (read from sim.json "evapotranspiration-method": "FAO-56-Dual")
+  // Irrigation physical params (isDripIrrigation, fw) are now set at the Irrigation workstep event level.
+  bool dualKcMethod{false};      //!< Use FAO-56 Dual Kc evaporation partitioning
 };
 
 

--- a/src/core/soilmoisture.cpp
+++ b/src/core/soilmoisture.cpp
@@ -335,6 +335,9 @@ void SoilMoisture::step(double vs_GroundwaterDepth,
     fm_BackwaterReplenishment();
   }
 
+  // Cache gross precipitation for Dual Kc fw logic (accessible in fm_Evapotranspiration)
+  vm_GrossPrecipitation = vw_Precipitation;
+
   fm_Evapotranspiration(vc_PercentageSoilCoverage, vc_KcFactor, siteParameters.vs_HeightNN, vw_MaxAirTemperature,
     vw_MinAirTemperature, vw_RelativeHumidity, vw_MeanAirTemperature, vw_WindSpeed, vw_WindSpeedHeight,
     vw_GlobalRadiation, vc_DevelopmentalStage, vs_JulianDay, vs_Latitude, vw_ReferenceEvapotranspiration);
@@ -911,6 +914,149 @@ void SoilMoisture::fm_Evapotranspiration(double vc_PercentageSoilCoverage, doubl
     }
 
     if (vm_PotentialEvapotranspiration > 0) { // Evaporation from soil
+
+      // -----------------------------------------------------------------------
+      // FAO-56 Dual Kc pathway — precompute potential soil evaporation (E_pot)
+      // using the Ke coefficient.  This block runs ONLY when:
+      //   • dualKcMethod is enabled in sim.json
+      //   • A crop is actually present (vc_DevelopmentalStage > 0)
+      // If either condition is false the existing Single Kc loop runs unchanged.
+      // -----------------------------------------------------------------------
+      const auto& simPs = monica.simulationParameters();
+      double vm_E_pot_dualKc = 0.0;      // [mm d-1] replaces (1-beta)*PET per layer
+      bool useDualKc = (simPs.dualKcMethod && vc_DevelopmentalStage > 0
+                        && cropModule != nullptr);
+
+      if (useDualKc) {
+        // ET0 is already in vm_ReferenceEvapotranspiration [mm d-1]
+        const double ET0 = vm_ReferenceEvapotranspiration;
+
+        // --- Kcb: basal crop coefficient (interpolated in crop module) ---
+        const double Kcb = cropModule->get_KcbFactor();
+
+        // --- Calculate Depletion first (FAO-56 §8.3) to inform memory logic ---
+        // Uses only the top soil layer (layer 0, typically 0-10 cm)
+        const double FC0  = vm_FieldCapacity[0];         // [m3 m-3]
+        const double WP0  = vm_PermanentWiltingPoint[0]; // [m3 m-3]
+        const double SWC0 = vm_SoilMoisture[0];          // [m3 m-3]
+        const double Ze   = 0.1;  // evaporation depth [m], FAO-56 typical top layer
+        // TEW: total evaporable water [mm] from top layer
+        const double TEW  = 1000.0 * (FC0 - 0.5 * WP0) * Ze;
+        
+        // A. Dynamic REW (FAO-56 Table 19 Mapping via Pedology)
+        double REW = 0.0;
+        std::string ka5Texture = soilColumn[0].vs_SoilTexture();
+        
+        if (ka5Texture == "Ss") REW = 2.5;
+        else if (ka5Texture == "Su2" || ka5Texture == "Sl2") REW = 3.5;
+        else if (ka5Texture == "Su3" || ka5Texture == "Sl3") REW = 4.5;
+        else if (ka5Texture == "Su4" || ka5Texture == "Sl4" || ka5Texture == "St2") REW = 5.5;
+        else if (ka5Texture == "St3" || ka5Texture == "Ls2" || ka5Texture == "Us2") REW = 8.0;
+        else if (ka5Texture == "Uu" || ka5Texture == "Us3" || ka5Texture == "Us4" || 
+                 ka5Texture == "Ul2" || ka5Texture == "Ul3" || ka5Texture == "Ul4") REW = 8.5;
+        else if (ka5Texture == "Ls3" || ka5Texture == "Ls4" || 
+                 ka5Texture == "Lu2" || ka5Texture == "Lu3" || ka5Texture == "Lu4") REW = 9.0;
+        else if (ka5Texture == "Ut2" || ka5Texture == "Ut3") REW = 9.5;
+        else if (ka5Texture == "Ut4" || ka5Texture == "Lt2" || ka5Texture == "Lt3" || ka5Texture == "Lts") REW = 10.5;
+        else if (ka5Texture == "Ts2" || ka5Texture == "Ts3" || ka5Texture == "Ts4" || 
+                 ka5Texture == "Tu2" || ka5Texture == "Tu3" || ka5Texture == "Tu4" || ka5Texture == "Tl") REW = 11.5;
+        else if (ka5Texture == "Tt") REW = 12.0;
+
+        // Fallback if KA5 lookup is unavailable or fails:
+        if (REW == 0.0) {
+            if (FC0 < 0.18) {
+            // Coarse soils (Sand, Sandy Loams): REW ranges from 2.0 to 7.0 mm
+                REW = 2.5 + 25.0 * (FC0 - 0.05);
+                REW = std::max(2.0, std::min(REW, 7.0));
+            } else if (FC0 >= 0.28) {
+            // Fine soils (Clays): REW ranges from 8.0 to 12.0 mm
+                REW = 8.0 + 20.0 * (FC0 - 0.28);
+                REW = std::max(8.0, std::min(REW, 12.0));
+            } else {
+                REW = 8.0;
+            }
+        }
+        REW = std::min(REW, TEW); // Hard boundary safety clamp
+
+        // Current depletion De [mm] = what the top layer is missing compared to FC
+        const double De   = 1000.0 * std::max(0.0, FC0 - SWC0) * Ze;
+
+        // --- Memory state update for wetting events ---
+        const double precip = vm_GrossPrecipitation;
+        const double irrigApplied = monica.dailySumIrrigationWater();
+        if (precip > 0.0) {
+          vm_LastWettingWasRain = true;
+        } else if (irrigApplied > 0.0) {
+          vm_LastWettingWasRain = false;
+        }
+
+        // --- fw: fraction of wetted soil surface (event-level, FAO-56 §8.3) ---
+        // Priority: rain today > persistent rain drying (Stage 1) > irrigation event fw.
+        // LIMITATION: Auto-irrigation uses defaults (fw=1.0, isDrip=false).
+        double fw_today;
+        if (precip > 0.0) {
+          fw_today = 1.0; // rain wets the full surface
+        } else if (De <= REW && vm_LastWettingWasRain) {
+          fw_today = 1.0; // still in Stage 1 drying from recent rain
+        } else {
+          fw_today = vm_irrigFwEvent; // carry/use the last Irrigation workstep fw
+        }
+        fw_today = std::max(0.0, std::min(fw_today, 1.0));
+
+        // Drip irrigation shading adjustment (FAO-56 §8.3):
+        //   fw_adj = fw * (1 - (2/3) * fc), where fc = fractional ground cover
+        // Applied if the current active wetting event was drip AND no rain today.
+        double fw_adj = fw_today;
+        if (vm_irrigIsDripEvent && !vm_LastWettingWasRain && precip == 0.0) {
+          fw_adj = fw_today * (1.0 - (2.0 / 3.0) * vc_PercentageSoilCoverage);
+          fw_adj = std::max(0.0, std::min(fw_adj, 1.0));
+        }
+
+        // --- Kr: evaporation reduction coefficient (FAO-56 §8.3) ---
+        double Kr = 1.0;
+        if (De > REW) {
+          if ((TEW - REW) > 0.0) {
+            Kr = (TEW - De) / (TEW - REW);
+          } else {
+            Kr = 0.0;
+          }
+        }
+        Kr = std::max(0.0, std::min(Kr, 1.0));
+
+        // B. Rigorous Climatic Kc_max (FAO-56 Equation 72)
+        // Uses native simulated crop height via get_CropHeight() — no hardcoded per-stage values.
+        double u2 = (vw_WindSpeed > 0.0) ? vw_WindSpeed : 2.0;
+        double eo_Tmax = 0.6108 * std::exp((17.27 * vw_MaxAirTemperature) / (vw_MaxAirTemperature + 237.3));
+        double eo_Tmin = 0.6108 * std::exp((17.27 * vw_MinAirTemperature) / (vw_MinAirTemperature + 237.3));
+        double RHmin = std::max(5.0, std::min(100.0, (eo_Tmin / eo_Tmax) * 100.0));
+        const double baseline = 1.2; // FAO-56 §6 default for most crops
+        double h = std::max(0.01, cropModule->get_CropHeight()); // native simulated height [m]
+        double Kc_max = baseline + (0.04 * (u2 - 2.0) - 0.004 * (RHmin - 45.0)) * std::pow(h / 3.0, 0.3);
+        Kc_max = std::max(Kc_max, Kcb + 0.05);
+
+        // C. few: fraction of exposed and wetted soil (FAO-56 Eq. 74)
+        double fc = std::max(0.0, std::min(vc_PercentageSoilCoverage, 0.99));
+        double few = std::min(1.0 - fc, fw_adj);
+        few = std::max(0.001, few); // guard against zero denominator
+
+        // --- Ke: soil evaporation coefficient (FAO-56 eq. 71) ---
+        double Ke = Kr * (Kc_max - Kcb);
+        Ke = std::min(Ke, few * Kc_max);
+        Ke = std::max(0.0, Ke);
+
+        // Potential soil evaporation [mm d-1]
+        vm_E_pot_dualKc = ET0 * Ke;
+        // Respect the hard cap from HERMES (6.5 mm/day applies to total, cap E too)
+        vm_E_pot_dualKc = std::min(vm_E_pot_dualKc, 6.5);
+
+        vm_Ke = Ke;
+      } else {
+        vm_Ke = 0.0;
+      }
+      // -----------------------------------------------------------------------
+      // End of Dual Kc precomputation
+      // -----------------------------------------------------------------------
+
       for (int i_Layer = 0; i_Layer < numberOfSoilLayers; i_Layer++) {
         vm_EReducer_1 = get_EReducer_1(i_Layer, vc_PercentageSoilCoverage,
           vm_PotentialEvapotranspiration);
@@ -942,13 +1088,23 @@ void SoilMoisture::fm_Evapotranspiration(double vc_PercentageSoilCoverage, doubl
         if (vc_DevelopmentalStage > 0) {
           // vegetation is present
 
-          //Interpolation between [0,1]
-          if (vc_PercentageSoilCoverage >= 0.0 && vc_PercentageSoilCoverage < 1.0) {
-            vm_Evaporation[i_Layer] = ((1.0 - vc_PercentageSoilCoverage) * vm_EReducer)
-              * vm_PotentialEvapotranspiration;
+          if (useDualKc) {
+            // ---------------------------------------------------------------
+            // FAO-56 Dual Kc: soil evaporation = Kr * (Kc_max - Kcb) * ET0
+            // The EReducer chain still applies (soil moisture, depth limits).
+            // Bypasses the Single Kc (1 - beta) * PET partitioning.
+            // ---------------------------------------------------------------
+            vm_Evaporation[i_Layer] = vm_EReducer * vm_E_pot_dualKc;
           } else {
-            if (vc_PercentageSoilCoverage >= 1.0) {
-              vm_Evaporation[i_Layer] = 0.0;
+            // Single Kc: original (1 - beta) * EReducer * PET partitioning
+            //Interpolation between [0,1]
+            if (vc_PercentageSoilCoverage >= 0.0 && vc_PercentageSoilCoverage < 1.0) {
+              vm_Evaporation[i_Layer] = ((1.0 - vc_PercentageSoilCoverage) * vm_EReducer)
+                * vm_PotentialEvapotranspiration;
+            } else {
+              if (vc_PercentageSoilCoverage >= 1.0) {
+                vm_Evaporation[i_Layer] = 0.0;
+              }
             }
           }
 
@@ -968,7 +1124,7 @@ void SoilMoisture::fm_Evapotranspiration(double vc_PercentageSoilCoverage, doubl
           }
 
         } else {
-          // no vegetation present
+          // no vegetation present — Single Kc / bare soil, always unchanged
           if (vm_SnowDepth > 0.0) {
             vm_Evaporation[i_Layer] = 0.0;
           } else {

--- a/src/core/soilmoisture.h
+++ b/src/core/soilmoisture.h
@@ -166,6 +166,11 @@ void step(double vs_DepthGroundwaterTable,
   double get_SumSurfaceRunOff() const { return vm_SumSurfaceRunOff; }
 
   double get_KcFactor() const;
+  double get_KeFactor() const { return vm_Ke; }
+
+  //! FAO-56 Dual Kc: allow Irrigation workstep to push event-level physical params into this module
+  void set_irrigFwEvent(double fw)       { vm_irrigFwEvent = fw; }
+  void set_irrigIsDripEvent(bool isDrip) { vm_irrigIsDripEvent = isDrip; }
 
   double vm_EvaporatedFromSurface{0.0}; //!< Amount of water evaporated from surface [mm]
 
@@ -212,6 +217,12 @@ private:
   int pm_LeachingDepthLayer{0};
   double pm_MaxPercolationRate{0.0}; //!< [mm d-1]
   double vc_NetPrecipitation{0.0}; //!< Precipitation amount that is not intercepted by vegetation [mm]
+  bool vm_LastWettingWasRain{false}; //!< True if the most recent surface wetting was rain (for FAO-56 Dual Kc)
+  double vm_Ke{0.0};                 //!< Soil evaporation coefficient (FAO-56 Dual Kc)
+  // FAO-56 Dual Kc: event-level irrigation physical parameters (written by Irrigation::apply).
+  // These replace the old global simPs.fw / simPs.isDripIrrigation.
+  double vm_irrigFwEvent{1.0};       //!< fw from the most recent Irrigation workstep [0-1]
+  bool   vm_irrigIsDripEvent{false}; //!< true if most recent Irrigation event was drip
   double vw_NetRadiation{0.0}; //!< [MJ m-2]
   std::vector<double> vm_PermanentWiltingPoint; //!< Soil water content at permanent wilting point [m3 m-3]
   double vc_PercentageSoilCoverage{0.0}; //!< [m2 m-2]

--- a/src/io/build-output.cpp
+++ b/src/io/build-output.cpp
@@ -811,6 +811,16 @@ BOTRes& monica::buildOutputTable() {
               return round(monica.soilMoisture().get_KcFactor(), 3);
             });
 
+      build({id++, "Kcb", "", "Basal crop coefficient (FAO-56 Dual Kc)"},
+            [](const MonicaModel& monica, OId oid) {
+              return monica.cropGrowth() ? round(monica.cropGrowth()->get_KcbFactor(), 3) : 0.0;
+            });
+
+      build({id++, "Ke", "", "Soil evaporation coefficient (FAO-56 Dual Kc)"},
+            [](const MonicaModel& monica, OId oid) {
+              return round(monica.soilMoisture().get_KeFactor(), 3);
+            });
+
       build({id++, "AtmCO2", "ppm", "Atmospheric CO2 concentration"},
             [](const MonicaModel& monica, OId oid) {
               return round(monica.get_AtmosphericCO2Concentration(), 0);

--- a/src/run/cultivation-method.cpp
+++ b/src/run/cultivation-method.cpp
@@ -1087,10 +1087,18 @@ bool Irrigation::apply(MonicaModel *model) {
 
 WSPtr monica::makeWorkstep(json11::Json j) {
   string type = string_value(j["type"]);
-  if (type == "Sowing"
-      || type == "Seed") { //deprecated name
-    return make_shared<Sowing>(j);
+  
+  if (type == "Sowing" || type == "Seed") {
+      return make_shared<Sowing>(j);
   }
+
+  // --- BEGIN TRANSPLANT WORKSTEP FACTORY REGISTRATION ---
+  else if (type == "Transplant") {
+      return make_shared<Transplant>(j);
+  }
+  // --- END TRANSPLANT WORKSTEP FACTORY REGISTRATION ---
+
+
   else if (type == "AutomaticSowing") {
     return make_shared<AutomaticSowing>(j);
   }
@@ -1528,3 +1536,74 @@ bool CultivationMethod::reinit(Tools::Date date, bool forceInitYear) {
 
   return addedYear;
 }
+
+
+// --- BEGIN TRANSPLANT WORKSTEP IMPLEMENTATION (PARSING) ---
+Transplant::Transplant(json11::Json object) {
+    // Mirror Sowing's constructor exactly: do NOT pass json to Workstep() base
+    // (that would call Workstep::merge once, then our merge() would call it again).
+    _errors.append(Transplant::merge(kj::mv(object)));
+}
+
+Transplant::Transplant(const Transplant& other) : Workstep(other) {
+    if (other._cropToPlant) {
+        _cropToPlant = kj::heap<Crop>(*other._cropToPlant);
+    }
+}
+
+json11::Json Transplant::to_json(bool includeFullCropParameters) const {
+    return json11::Json::object{ { "type", type() } };
+}
+
+Tools::Errors Transplant::merge(json11::Json j) {
+    // --- Step 1: Parse date and base Workstep fields (mirrors Sowing::merge) ---
+    Errors res = Workstep::merge(j);
+
+    // --- Step 2: Allocate Crop and call merge exactly like Sowing does ---
+    _cropToPlant = nullptr;
+    _cropToPlant = kj::heap<Crop>();
+    res.append(_cropToPlant->merge(j["crop"]));   // identical to Sowing::merge line 206
+
+    // Set seed date on the crop object exactly like Sowing::merge line 208
+    _cropToPlant->setSeedDate(date());
+
+    // --- Step 3: Parse transplant-specific numerical parameters ---
+    if (!j["initialStage"].is_null())          { _initialStage = static_cast<size_t>(j["initialStage"].int_value()); }
+    if (!j["initialTemperatureSum"].is_null())  { _initialGDD   = j["initialTemperatureSum"].number_value(); }
+    if (!j["initialRootBiomass"].is_null())     { _initRootMass  = j["initialRootBiomass"].number_value(); }
+    if (!j["initialLeafBiomass"].is_null())     { _initLeafMass  = j["initialLeafBiomass"].number_value(); }
+    if (!j["initialShootBiomass"].is_null())    { _initShootMass = j["initialShootBiomass"].number_value(); }
+    if (!j["initialLAI"].is_null())             { _initLAI       = j["initialLAI"].number_value(); }
+    if (!j["postTransplantDelay"].is_null())    { _postTransplantDelay = j["postTransplantDelay"].int_value(); }
+
+    return res;   // propagates ALL sub-errors (crop parse errors included)
+}
+// --- END TRANSPLANT WORKSTEP IMPLEMENTATION (PARSING) ---
+
+// --- BEGIN TRANSPLANT WORKSTEP IMPLEMENTATION (EXECUTION) ---
+bool Transplant::apply(MonicaModel* model) {
+    // Step 1: Call base Workstep::apply (required by event system - mirrors Sowing::apply line 228)
+    Workstep::apply(model);
+
+    if (!model) return false;
+
+    // Guard: _cropToPlant must exist and be valid
+    if (!_cropToPlant || !_cropToPlant->isValid()) return false;
+
+    // Step 2: Seed crop - identical to Sowing::apply line 231
+    model->seedCrop(_cropToPlant.get());
+
+    // Step 3: Get the crop engine created by seedCrop
+    CropModule* cropModule = model->cropGrowth();
+    if (!cropModule) return false;
+
+    // Step 4: Force the transplant initial state (overrides germination defaults)
+    cropModule->forceTransplantState(_initialGDD, _initLAI, _initialStage,
+                                     _initRootMass, _initLeafMass, _initShootMass, _postTransplantDelay);
+
+    // Step 5: Register the event
+    model->addEvent("Transplant");
+
+    return true;
+}
+// --- END TRANSPLANT WORKSTEP IMPLEMENTATION (EXECUTION) ---

--- a/src/run/cultivation-method.cpp
+++ b/src/run/cultivation-method.cpp
@@ -209,6 +209,9 @@ Errors Sowing::merge(json11::Json j) {
   set_int_value(_plantDensity, j, "PlantDensity");
   if (_plantDensity > 0)
     _crop->cropParameters().speciesParams.pc_PlantDensity = _plantDensity;
+  // FAO-56 Dual Kc: optional initial Kcb at sowing (default 0.15 = bare soil)
+  if (j["initialKcb"].is_number())
+    _initialKcb = j["initialKcb"].number_value();
   return res;
 }
 
@@ -229,6 +232,9 @@ bool Sowing::apply(MonicaModel *model) {
 
   debug() << "sowing crop: " << _crop->toString() << " at: " << _crop->seedDate().toString() << endl;
   model->seedCrop(_cropToPlant.get());
+  // FAO-56 Dual Kc: push initial Kcb into the freshly created crop module
+  if (model->simulationParameters().dualKcMethod && model->cropGrowth())
+    model->cropGrowth()->setInitialKcb(_initialKcb);
   model->addEvent("Sowing");
 
   return true;
@@ -1061,8 +1067,15 @@ Irrigation::Irrigation(json11::Json j) {
 Errors Irrigation::merge(json11::Json j) {
   Errors res = Workstep::merge(j);
   set_double_value(_amount, j, "amount");
-  if (j["parameters"].is_object())
+  if (j["parameters"].is_object()) {
     set_value_obj_value(_params, j, "parameters");
+    // FAO-56 Dual Kc: event-level irrigation physical params
+    const auto& params = j["parameters"];
+    if (params["isDripIrrigation"].is_bool())
+      _isDripIrrigation = params["isDripIrrigation"].bool_value();
+    if (params["fw"].is_number())
+      _fw = std::max(0.0, std::min(1.0, params["fw"].number_value()));
+  }
   return res;
 }
 
@@ -1079,6 +1092,12 @@ bool Irrigation::apply(MonicaModel *model) {
 
   //cout << toString() << endl;
   model->applyIrrigation(amount(), nitrateConcentration());
+  // FAO-56 Dual Kc: push event-level fw and isDrip into SoilMoisture for today's ET calculation
+  // LIMITATION: Auto-irrigation uses sim.json params or defaults (fw=1.0, isDrip=false).
+  if (model->simulationParameters().dualKcMethod) {
+    model->soilMoistureNC().set_irrigFwEvent(_fw);
+    model->soilMoistureNC().set_irrigIsDripEvent(_isDripIrrigation);
+  }
   model->addEvent("Irrigation");
 
   return true;
@@ -1575,6 +1594,8 @@ Tools::Errors Transplant::merge(json11::Json j) {
     if (!j["initialShootBiomass"].is_null())    { _initShootMass = j["initialShootBiomass"].number_value(); }
     if (!j["initialLAI"].is_null())             { _initLAI       = j["initialLAI"].number_value(); }
     if (!j["postTransplantDelay"].is_null())    { _postTransplantDelay = j["postTransplantDelay"].int_value(); }
+    // FAO-56 Dual Kc: optional initial Kcb at transplanting (default 0.15 = bare soil)
+    if (!j["initialKcb"].is_null())             { _initialKcb = j["initialKcb"].number_value(); }
 
     return res;   // propagates ALL sub-errors (crop parse errors included)
 }
@@ -1601,7 +1622,11 @@ bool Transplant::apply(MonicaModel* model) {
     cropModule->forceTransplantState(_initialGDD, _initLAI, _initialStage,
                                      _initRootMass, _initLeafMass, _initShootMass, _postTransplantDelay);
 
-    // Step 5: Register the event
+    // Step 5: FAO-56 Dual Kc: push initial Kcb into the crop module
+    if (model->simulationParameters().dualKcMethod)
+      cropModule->setInitialKcb(_initialKcb);
+
+    // Step 6: Register the event
     model->addEvent("Transplant");
 
     return true;

--- a/src/run/cultivation-method.h
+++ b/src/run/cultivation-method.h
@@ -219,6 +219,46 @@ private:
   bool _cropSeeded{false};
 };
 
+
+// --- BEGIN TRANSPLANT WORKSTEP IMPLEMENTATION ---
+class DLL_API Transplant : public Workstep {
+public:
+    Transplant() = default;
+    explicit Transplant(json11::Json object);
+    Transplant(const Transplant& other);
+
+    virtual Transplant* clone() const override { return new Transplant(*this); }
+
+    // Parse parameters from JSON
+    Tools::Errors merge(json11::Json j) override;
+    json11::Json to_json() const override { return to_json(true); }
+    json11::Json to_json(bool includeFullCropParameters) const;
+
+    virtual std::string type() const override { return "Transplant"; }
+
+    // Execution/application inside MONICA runner
+    bool apply(MonicaModel* model) override;
+
+    void setDate(Tools::Date date) override {
+        this->_date = date;
+        if (_cropToPlant) _cropToPlant->setSeedDate(date);
+    }
+
+private:
+    kj::Own<Crop> _cropToPlant; // Manages the genetic characteristics of the crop to plant
+
+    // Seedling initial parameters forced at transplanting
+    size_t _initialStage{ 2 };
+    double _initialGDD{ 0.0 };
+    double _initRootMass{ 0.0 };
+    double _initLeafMass{ 0.0 };
+    double _initShootMass{ 0.0 };
+    double _initLAI{ 0.0 };
+    int _postTransplantDelay{ 0 };
+};
+// --- END TRANSPLANT WORKSTEP IMPLEMENTATION ---
+
+
 class DLL_API Harvest : public Workstep {
 public:
   enum CropUsage {

--- a/src/run/cultivation-method.h
+++ b/src/run/cultivation-method.h
@@ -158,6 +158,7 @@ private:
   kj::Own<Crop> _cropToPlant;
   Crop *_crop{nullptr};
   int _plantDensity{-1}; //[plants m-2]
+  double _initialKcb{0.15}; //!< FAO-56 Dual Kc: initial Kcb at planting (default = 0.15)
 };
 
 class DLL_API AutomaticSowing : public Sowing {
@@ -255,6 +256,7 @@ private:
     double _initShootMass{ 0.0 };
     double _initLAI{ 0.0 };
     int _postTransplantDelay{ 0 };
+    double _initialKcb{0.15}; //!< FAO-56 Dual Kc: initial Kcb at transplanting (default = 0.15)
 };
 // --- END TRANSPLANT WORKSTEP IMPLEMENTATION ---
 
@@ -615,6 +617,9 @@ public:
 private:
   double _amount{0};
   IrrigationParameters _params;
+  // FAO-56 Dual Kc: event-level irrigation physical parameters
+  bool   _isDripIrrigation{false}; //!< true = drip irrigation (shading adjustment applied)
+  double _fw{1.0};                 //!< fraction of wetted soil surface [0-1]
 };
 
 DLL_API WSPtr makeWorkstep(json11::Json object);


### PR DESCRIPTION
### TRANSPLANT MODULE
Introduced structural support for a new "Transplanting" workstep type within the cultivation management engine, allowing simulations to bypass the seed-germination phase and initialize a crop at an advanced developmental stage.

1. Cultivation Management Architecture
- Added the `Transplant` class inside `src/run/cultivation-method.h` and `.cpp` to handle transplanting as a dedicated field operation type.
- Updated the workstep parsing logic in `Transplant::merge()` to read specific initialization arguments from `crop.json` (such as `"initialStage"` and `"initialLAI"`).
- Wired `Transplant::apply()` into the main simulation loop to trigger crop initialization dynamically on the scheduled event date.

2. Crop Module State Overrides
- Integrated the transplanting event with the `CropModule` initialization sequence.
- Allows the model to force-set the initial developmental stage (`vc_DevelopmentalStage`) and initial Leaf Area Index (`vc_LAI`) directly from the workstep parameters, overriding the default absolute-zero seeding state.
- Ensures proper initialization of biomass partitions and thermal accumulation base-levels corresponding to the pre-developed seedling's stage at the time of field insertion.
- Implements a process-based transplant shock linear recovery function that reduces daily gross photosynthesis and total root effectivity within the period defined by the transplant date to the end of 'postTransplantDelay".

3. JSON Schema & Backward Compatibility
- Expanded the cultivation event schema to support:
  ```json
  {
    "type": "Transplant",
    "date": "2026-05-05",
    "crop": ...
    "initialStage": 1,
    "initialTemperatureSum": 130.0,
    "initialRootBiomass": 2.6,
    "initialLeafBiomass": 3.3,
    "initialShootBiomass": 1.8,
    "initialLAI": 0.01,
    "postTransplantDelay": 14
  }
- Maintained strict backward compatibility: the traditional "Sowing" workstep and all native phenological routines remain completely unaffected if the transplanting event is not called.

[MONICA transplant module.docx](https://github.com/user-attachments/files/28554021/MONICA.transplant.module.docx)

### DUAL Kc
Refactored the core hydrology and crop growth modules to introduce the FAO-56 Dual Kc approach ("FAO-56-Dual": https://www.fao.org/4/x0490e/x0490e0c.htm#TopOfPage).

1. Crop Module: Dynamic GDD-Driven Kcb Curve
- Implemented a daily dynamic 4-phase trapezoidal basal crop coefficient (Kcb) curve entirely driven by Growing Degree Days (GDD).
- Natively supports both seeding (Sowing) and transplanting (Transplant) events by tracking cumulative theoretical GDD timelines.
- Automated mid-season plateau calculation (Kcb_mid) using max_Kc as a full-ground-coverage proxy (subtracts 0.05 if max_Kc >= 1.0, else 0.10) and fixed terminal target (Kcb_end = Kc_end - 0.05).

2. Soil Moisture: Process-Based Hydrology & Memory
- Solved the "day-after-rain" underestimation by introducing a persistent wetting memory variable (`vm_LastWettingWasRain`), maintaining fw = 1.0 while topsoil depletion is within readily evaporable limits (De <= REW).
- Dynamically maps Readily Evaporable Water (REW) based on the topsoil layer's native German KA5 soil texture classification (utilizing Field Capacity proxies as a robust fallback).
- Implemented climatic Kc_max formulation (FAO-56 Eq. 72), fed daily by native simulated plant height (`get_CropHeight()`) and context weather data.
- Implemented the explicit fraction of exposed and wetted soil (few, FAO-56 Eq. 74) interacting directly with MONICA’s canopy coverage shading (beta).

3. Cultivation Method: Event-Level Irrigation Architecture
- Allows to specify 'initialKcb' within Sowing or Transplant worksteps properties (default = 0.15)
- Allows to specify physical system properties directly into the Irrigation worksteps within `crop.json` ('isDripIrrigation' - default = false - and 'fw' - default = 1.0), allowing the model to process mixed irrigation managements (e.g., alternating overhead wetting and localized drip) dynamically inside a single simulation run.
- Configured robust defaults for backward compatibility (defaults to "Penman-Monteith" single Kc, and manual worksteps default to fw = 1.0, isDrip = false).
